### PR TITLE
Add useEffect to Item List for filtered rendering

### DIFF
--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import useFirebaseSnapshot from '../hooks/useFirebaseSnapshot.js';
 import cleanData from '../utils/cleanData.js';
 import { Link } from 'react-router-dom';
+import { useEffect } from 'react/cjs/react.development';
 
 const ItemList = () => {
   const { docs, loading } = useFirebaseSnapshot();
@@ -39,6 +40,12 @@ const ItemList = () => {
     });
     setFilteredResults(results);
   };
+
+  useEffect(() => {
+    if (searchInput) {
+      filterItems(searchInput);
+    }
+  }, [docs]);
 
   const handleClear = () => {
     setSearchInput('');

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -11,7 +11,6 @@ import { Link } from 'react-router-dom';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import useFirebaseSnapshot from '../hooks/useFirebaseSnapshot.js';
 import cleanData from '../utils/cleanData.js';
-import { Link } from 'react-router-dom';
 
 
 const ItemList = () => {


### PR DESCRIPTION
## Description

Adds a useEffect hook to the Item List in order to address the bug where checking off filtered items did not render checked status. 

## Related Issue

Closes #30 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![Screen Shot 2022-02-06 at 2 50 07 PM](https://user-images.githubusercontent.com/83732773/152704878-b1048f84-cecf-4a3f-91b2-87427a161e29.png)

### After
![Screen Shot 2022-02-06 at 2 50 52 PM](https://user-images.githubusercontent.com/83732773/152704904-6cae864d-c710-4989-aa0f-4f3c23d1071e.png)

## Testing Steps / QA Criteria

Add an item to the list, go to list view, enter letters into the filter input to bring up the just added item. Upon clicking the checkbox, a check should now show.

