### PR TITLE
Add token context that allows private routes based on token presence …

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,7 @@
   font-weight: bold;
 }
 
-.route-links {
+nav {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/App.js
+++ b/src/App.js
@@ -1,43 +1,48 @@
 import React from 'react';
 import './App.css';
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  NavLink,
-} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import AddItem from './components/AddItem';
 import ItemList from './components/ItemList';
 import Home from './pages/Home';
 
-import {
-  getToken,
-  words,
-  calculateEstimate,
-} from '@the-collab-lab/shopping-list-utils';
-import { useNavigate } from 'react-router-dom';
+import Nav from './components/Nav';
+import { TokenProvider } from './context/TokenContext';
+import PrivateRoute from './components/PrivateRoute';
 
 function App() {
   let token;
   token = localStorage.getItem('token');
 
   return (
-    <div className="App">
-      <Router>
-        <div className="main-content">
-          <Routes>
-            {/* //later add conditional to be able to go to home page through navigation */}
-            <Route path="/" element={!token ? <Home /> : <ItemList />} />
-            <Route element={<ItemList />} path="/list" />
-            <Route element={<AddItem />} path="/add-item" />
-          </Routes>
-        </div>
-        <div className="route-links">
-          <NavLink to="/list">Item List</NavLink>
-          <NavLink to="/add-item">Add Item</NavLink>
-        </div>
-      </Router>
-    </div>
+    <TokenProvider>
+      <div className="App">
+        <Router>
+          <div className="main-content">
+            <Routes>
+              {/* //later add conditional to be able to go to home page through navigation */}
+              <Route path="/" element={!token ? <Home /> : <ItemList />} />
+              <Route
+                element={
+                  <PrivateRoute>
+                    <ItemList />
+                  </PrivateRoute>
+                }
+                path="/list"
+              />
+              <Route
+                element={
+                  <PrivateRoute>
+                    <AddItem />
+                  </PrivateRoute>
+                }
+                path="/add-item"
+              />
+            </Routes>
+          </div>
+          <Nav />
+        </Router>
+      </div>
+    </TokenProvider>
   );
 }
 

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,0 +1,18 @@
+import { NavLink } from 'react-router-dom';
+import { useToken } from '../context/TokenContext';
+
+export default function Nav() {
+  const { hasToken } = useToken();
+
+  return (
+    <nav>
+      {' '}
+      {hasToken && (
+        <>
+          <NavLink to="/list">Item List</NavLink>
+          <NavLink to="/add-item">Add Item</NavLink>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,8 @@
+import { Navigate } from 'react-router-dom';
+import { useToken } from '../context/TokenContext';
+
+export default function PrivateRoute({ children }) {
+  const { hasToken } = useToken();
+
+  return hasToken ? children : <Navigate to="/" />;
+}

--- a/src/context/TokenContext.js
+++ b/src/context/TokenContext.js
@@ -1,0 +1,24 @@
+import { createContext, useContext, useMemo, useState } from 'react';
+
+const TokenContext = createContext();
+
+const TokenProvider = ({ children }) => {
+  const token = localStorage.getItem('token');
+  const [hasToken, setHasToken] = useState(token ? token : '');
+
+  const value = useMemo(() => ({ hasToken, setHasToken }), [hasToken]);
+
+  return (
+    <TokenContext.Provider value={value}>{children}</TokenContext.Provider>
+  );
+};
+
+const useToken = () => {
+  const context = useContext(TokenContext);
+  if (context === undefined) {
+    throw new Error('useToken not used inside TokenProvider');
+  }
+  return context;
+};
+
+export { TokenContext, TokenProvider, useToken };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -6,15 +6,19 @@ import {
 } from '@the-collab-lab/shopping-list-utils';
 import useFirebaseSnapshot from '../hooks/useFirebaseSnapshot.js';
 import { useNavigate } from 'react-router-dom';
+import { useToken } from '../context/TokenContext.js';
 
 const Home = () => {
   const navigate = useNavigate();
   const { docs } = useFirebaseSnapshot();
   const [userToken, setUserToken] = useState('');
   const existingTokens = docs.map((doc) => doc.data.token);
+  const { setHasToken } = useToken();
 
   const createToken = () => {
-    localStorage.setItem('token', getToken());
+    const newToken = getToken();
+    localStorage.setItem('token', newToken);
+    setHasToken(newToken);
     navigate('/list');
   };
 
@@ -26,6 +30,7 @@ const Home = () => {
     e.preventDefault();
     if (existingTokens.includes(userToken) && userToken !== '') {
       saveToken(userToken);
+      setHasToken(userToken);
       navigate('/list');
     } else {
       alert('Token does not exist, please try again or create a new list.');


### PR DESCRIPTION
…and redirect without

## Description

This PR adds a token context that is used in the nav component (to only show item list and add item links if a token is present), in the new private route component (to wrap item list and add item routes so a redirect to home happens without a token), and in the home view since the token is first set there.

## Related Issue

Closes #25 and #28. 

## Acceptance Criteria

- When visiting the first page of the app without a list, the Item List and Add Item links are not visible.
- If navigating to the list view and no token is stored in Local Storage, the user should be redirected to the main page.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![Screen Shot 2022-02-08 at 5 48 40 PM](https://user-images.githubusercontent.com/83732773/153106499-b6be1ee8-ccfc-4a1c-a510-4e71624727b6.png)

### After
![Screen Shot 2022-02-08 at 5 49 22 PM](https://user-images.githubusercontent.com/83732773/153106504-c68c831f-d68a-48cc-89ca-2b7f682ac5d7.png)

## Testing Steps / QA Criteria
First ensure you don't have a token in local storage. Without that, no nav links should appear at the bottom of the homepage. Also, upon inputting the url directly to item list (/list) and to add item (/add-item), you should be redirected to the homepage . 
