### PR TITLE
Ck dm shopping list order

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,3 +30,19 @@ ul {
 #filter-items {
   margin: 0 20px;
 }
+
+.soon {
+  color: red;
+}
+
+.kindofsoon {
+  color: orange;
+}
+
+.notsoon {
+  color: blue;
+}
+
+.inactive {
+  color: darkgray;
+}

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -118,9 +118,11 @@ const ItemList = () => {
               ? filteredResults.map((item) => (
                   <li
                     key={item.id}
-                    aria-label={`Need to buy ${item.data.name} ${itemStatus(
-                      item,
-                    )}`}
+                    aria-label={
+                      itemStatus(item) === 'inactive'
+                        ? `${item.data.name} is inactive`
+                        : `Need to buy ${item.data.name} ${itemStatus(item)}`
+                    }
                     className={itemStatus(item).replace(/\s+/g, '')}
                   >
                     {' '}
@@ -144,9 +146,11 @@ const ItemList = () => {
               : docs.map((item) => (
                   <li
                     key={item.id}
-                    aria-label={`Need to buy ${item.data.name} ${itemStatus(
-                      item,
-                    )}`}
+                    aria-label={
+                      itemStatus(item) === 'inactive'
+                        ? `${item.data.name} is inactive`
+                        : `Need to buy ${item.data.name} ${itemStatus(item)}`
+                    }
                     className={itemStatus(item).replace(/\s+/g, '')}
                   >
                     {' '}

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import useFirebaseSnapshot from '../hooks/useFirebaseSnapshot.js';
 import cleanData from '../utils/cleanData.js';
-
+import itemStatus from '../utils/itemStatus.js';
 
 const ItemList = () => {
   const { docs, loading } = useFirebaseSnapshot();
@@ -41,7 +41,10 @@ const ItemList = () => {
     // Seconds in 24 hours
     // 60 x 60 x 24 = 86400
     if (item.data['last purchased']) {
-      if (Timestamp.now().seconds - item.data['last purchased'].seconds < 86400) {
+      if (
+        Timestamp.now().seconds - item.data['last purchased'].seconds <
+        86400
+      ) {
         return true;
       }
     }

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -81,7 +81,7 @@ const ItemList = () => {
       await deleteDoc(docRef);
     }
   };
-
+  // currently, we are rendering items with 'soon' as red, 'kind of soon' as orange, 'not soon' as blue, and 'inactive' as grey.
   return (
     <>
       <h2>Smart Shopping List</h2>
@@ -132,7 +132,6 @@ const ItemList = () => {
                       disabled={within24Hours(item)}
                     />{' '}
                     {item.data.name}
-                    {itemStatus(item)}
                     <button
                       type="button"
                       aria-label={`delete ${item.data.name}`}
@@ -159,7 +158,9 @@ const ItemList = () => {
                       disabled={within24Hours(item)}
                     />{' '}
                     {item.data.name}
-                    {itemStatus(item)}
+                    {/* {itemStatus(item)} */}
+                    {/* {' np: ' + item.data['next purchase']}
+                    {' epi: ' + item.data['estimated purchase interval']} */}
                     <button
                       type="button"
                       aria-label={`delete ${item.data.name}`}

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -116,7 +116,13 @@ const ItemList = () => {
           <ul>
             {filteredResults
               ? filteredResults.map((item) => (
-                  <li key={item.id}>
+                  <li
+                    key={item.id}
+                    aria-label={`Need to buy ${item.data.name} ${itemStatus(
+                      item,
+                    )}`}
+                    className={itemStatus(item).replace(/\s+/g, '')}
+                  >
                     {' '}
                     <input
                       aria-label="purchase item"
@@ -126,6 +132,7 @@ const ItemList = () => {
                       disabled={within24Hours(item)}
                     />{' '}
                     {item.data.name}
+                    {itemStatus(item)}
                     <button
                       type="button"
                       aria-label={`delete ${item.data.name}`}
@@ -136,7 +143,13 @@ const ItemList = () => {
                   </li>
                 ))
               : docs.map((item) => (
-                  <li key={item.id}>
+                  <li
+                    key={item.id}
+                    aria-label={`Need to buy ${item.data.name} ${itemStatus(
+                      item,
+                    )}`}
+                    className={itemStatus(item).replace(/\s+/g, '')}
+                  >
                     {' '}
                     <input
                       aria-label="purchase item"
@@ -146,6 +159,7 @@ const ItemList = () => {
                       disabled={within24Hours(item)}
                     />{' '}
                     {item.data.name}
+                    {itemStatus(item)}
                     <button
                       type="button"
                       aria-label={`delete ${item.data.name}`}

--- a/src/hooks/useFirebaseSnapshot.js
+++ b/src/hooks/useFirebaseSnapshot.js
@@ -19,6 +19,22 @@ export default function useFirebaseSnapshot() {
       querySnapshot.forEach((doc) => {
         items.push({ data: doc.data(), id: doc.id });
       });
+      //sort items
+      items.sort((item1, item2) => {
+        let sortNum1, sortNum2;
+        //check to see which data we are using for sorting based on purchase history
+        //sort using next purchase data if < 1 purchases, sort using estimated purchase interval if 1 or more purchases
+        !item1.data['total purchases']
+          ? (sortNum1 = item1.data['next purchase'])
+          : (sortNum1 = item1.data['estimated purchase interval']);
+        !item2.data['total purchases']
+          ? (sortNum2 = item2.data['next purchase'])
+          : (sortNum2 = item2.data['estimated purchase interval']);
+        return (
+          //sort with sort nums, or if nums equal, sort based on alphabetical order of item name
+          sortNum1 - sortNum2 || item1.data.name.localeCompare(item2.data.name)
+        );
+      });
       setDocs(items);
       setLoading(false);
     });

--- a/src/hooks/useFirebaseSnapshot.js
+++ b/src/hooks/useFirebaseSnapshot.js
@@ -1,6 +1,7 @@
 import { collection, query, where, onSnapshot } from 'firebase/firestore';
 import { db } from '../lib/firebase.js';
 import { useState, useEffect } from 'react';
+import itemStatus from '../utils/itemStatus.js';
 
 export default function useFirebaseSnapshot() {
   const [docs, setDocs] = useState([]);
@@ -22,14 +23,23 @@ export default function useFirebaseSnapshot() {
       //sort items
       items.sort((item1, item2) => {
         let sortNum1, sortNum2;
+
         //check to see which data we are using for sorting based on purchase history
         //sort using next purchase data if < 1 purchases, sort using estimated purchase interval if 1 or more purchases
         !item1.data['total purchases']
           ? (sortNum1 = item1.data['next purchase'])
           : (sortNum1 = item1.data['estimated purchase interval']);
+
+        //check for inactives
+        if (itemStatus(item1) === 'inactive') sortNum1 = 1000;
+
         !item2.data['total purchases']
           ? (sortNum2 = item2.data['next purchase'])
           : (sortNum2 = item2.data['estimated purchase interval']);
+
+        //check for inactives
+        if (itemStatus(item2) === 'inactive') sortNum2 = 1000;
+
         return (
           //sort with sort nums, or if nums equal, sort based on alphabetical order of item name
           sortNum1 - sortNum2 || item1.data.name.localeCompare(item2.data.name)

--- a/src/utils/itemSort.js
+++ b/src/utils/itemSort.js
@@ -1,0 +1,2 @@
+//util function for sorting items based on estimated purchase interval
+//to possibly be used inside custom fb hook

--- a/src/utils/itemSort.js
+++ b/src/utils/itemSort.js
@@ -1,2 +1,0 @@
-//util function for sorting items based on estimated purchase interval
-//to possibly be used inside custom fb hook

--- a/src/utils/itemStatus.js
+++ b/src/utils/itemStatus.js
@@ -21,4 +21,5 @@ export default function itemStatus(item) {
     if (item.data['estimated purchase interval'] <= 30) return 'kind of soon';
     if (item.data['estimated purchase interval'] > 30) return 'not soon';
   }
+  return 'no status';
 }

--- a/src/utils/itemStatus.js
+++ b/src/utils/itemStatus.js
@@ -1,0 +1,24 @@
+import { Timestamp } from 'firebase/firestore';
+
+export default function itemStatus(item) {
+  //no purchase history
+  if (!item.data['last purchased']) {
+    if (item.data['next purchase'] === 7) return 'soon';
+    if (item.data['next purchase'] === 14) return 'kind of soon';
+    if (item.data['next purchase'] === 30) return 'not soon';
+  }
+  // double the estimated purchase interval
+  const daysSinceLastPurchased = item.data['last purchased']
+    ? Math.round((Timestamp.now() - item.data['last purchased']) / 86400)
+    : 0;
+  if (daysSinceLastPurchased >= item.data['estimated purchase interval'] * 2)
+    return 'inactive';
+  // 1 purchase only
+  if (item.data['total purchases'] === 1) return 'inactive';
+  // 2 or more purchases
+  if (item.data['total purchases'] > 1) {
+    if (item.data['estimated purchase interval'] < 7) return 'soon';
+    if (item.data['estimated purchase interval'] <= 30) return 'kind of soon';
+    if (item.data['estimated purchase interval'] > 30) return 'not soon';
+  }
+}

--- a/src/utils/itemStatus.js
+++ b/src/utils/itemStatus.js
@@ -2,7 +2,7 @@ import { Timestamp } from 'firebase/firestore';
 
 export default function itemStatus(item) {
   //no purchase history
-  if (!item.data['last purchased']) {
+  if (!item.data['total purchases']) {
     if (item.data['next purchase'] === 7) return 'soon';
     if (item.data['next purchase'] === 14) return 'kind of soon';
     if (item.data['next purchase'] === 30) return 'not soon';

--- a/src/utils/itemStatus.test.js
+++ b/src/utils/itemStatus.test.js
@@ -1,0 +1,99 @@
+import itemStatus from './itemStatus';
+import { Timestamp } from 'firebase/firestore';
+
+//item never purchased, selected soon
+const item1 = {
+  data: {
+    name: 'item1',
+    'next purchase': 7,
+    'estimated purchase interval': 0,
+    'last purchased': null,
+    'total purchases': 0,
+    token: 'sage window alpha',
+  },
+  id: 1,
+};
+//item never purchased, selected kind of soon
+const item2 = {
+  data: {
+    name: 'item2',
+    'next purchase': 14,
+    'estimated purchase interval': 0,
+    'last purchased': null,
+    'total purchases': 0,
+    token: 'sage window alpha',
+  },
+  id: 2,
+};
+//item never purchased, selected not soon
+const item3 = {
+  data: {
+    name: 'item3',
+    'next purchase': 30,
+    'estimated purchase interval': 0,
+    'last purchased': null,
+    'total purchases': 0,
+    token: 'sage window alpha',
+  },
+  id: 3,
+};
+//item purchased once
+const item4 = {
+  data: {
+    name: 'item4',
+    'next purchase': 7,
+    'estimated purchase interval': 7,
+    'last purchased': null,
+    'total purchases': 1,
+    token: 'sage window alpha',
+  },
+  id: 3,
+};
+// double the estimated purchase interval
+const item5 = {
+  data: {
+    name: 'item5',
+    'next purchase': 7,
+    'estimated purchase interval': 2,
+    'last purchased': Timestamp.fromDate(new Date('02/13/2022')),
+    'total purchases': 2,
+    token: 'sage window alpha',
+  },
+  id: 5,
+};
+// more than two purchases
+const item6 = {
+  data: {
+    name: 'item6',
+    'next purchase': 30,
+    'estimated purchase interval': 12,
+    'last purchased': null,
+    'total purchases': 2,
+    token: 'sage window alpha',
+  },
+  id: 6,
+};
+
+test('item1 returns soon', () => {
+  expect(itemStatus(item1)).toBe('soon');
+});
+
+test('item2 returns kind of soon', () => {
+  expect(itemStatus(item2)).toBe('kind of soon');
+});
+
+test('item3 returns not soon', () => {
+  expect(itemStatus(item3)).toBe('not soon');
+});
+
+test('item4 returns inactive', () => {
+  expect(itemStatus(item4)).toBe('inactive');
+});
+
+test('item5 returns inactive', () => {
+  expect(itemStatus(item5)).toBe('inactive');
+});
+
+test('item6 returns kind of soon', () => {
+  expect(itemStatus(item6)).toBe('kind of soon');
+});


### PR DESCRIPTION
## Description

This PR adds an item sort to the useFirebaseSnapshot custom hook in order to return a list of items arranged based on next purchase date. It also adds an itemStatus utility function that returns "soon," "kind of soon," "not soon," or "inactive" also based on next purchase date. The itemStatus utility is used in the className of the individual item render in order to be styled differently based status, as well as in the aria label to provide a screen-reader-friendly status message. 

Please note: the current status-based styling is meant to be a placeholder ahead of actual design implementation.

## Related Issue

Closes #12 

## Acceptance Criteria

* Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
* Items should be sorted by the estimated number of days until the next purchase
* Items with the same number of estimated days until next purchase should be sorted alphabetically
* Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

| Before | After |
|---|---|
| ![Screen Shot 2022-02-15 at 5 45 13 PM](https://user-images.githubusercontent.com/83732773/154180589-a1fbd3b5-3ae4-4539-8e10-5ca2abf97f02.png) | ![Screen Shot 2022-02-15 at 5 45 49 PM](https://user-images.githubusercontent.com/83732773/154180606-07f8a8f2-fcba-4423-b84a-ea209fd97ae7.png) |


## Testing Steps / QA Criteria

Pull down branch and run the app. Items in your list should be rendered in different colors based on status, and ordered based on next purchase date. In ItemList.js, you can comment back in lines 161-163 in order to see the actual next purchase/estimated purchase interval data for each item to confirm accurate sort order. Try adding new items to check that those are ordered and rendered as expected. For example, a new item added as "Kind of soon" should show up in orange towards the middle of the list. 

Note: there is also a Jest test that is included that tests the itemStatus utility function used in this PR. You can run it by typing: `npm test` in the command line.
