### PR TITLE
Install flipmove animation dependency, animate item list.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "firebase": "^9.6.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-flip-move": "^3.0.4",
         "react-router-dom": "^6.2.1",
         "react-scripts": "4.0.1"
       },
@@ -15703,6 +15704,15 @@
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+    },
+    "node_modules/react-flip-move": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
+      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
+      "peerDependencies": {
+        "react": ">=16.3.x",
+        "react-dom": ">=16.3.x"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -33477,6 +33487,12 @@
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+    },
+    "react-flip-move": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
+      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "firebase": "^9.6.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-flip-move": "^3.0.4",
     "react-router-dom": "^6.2.1",
     "react-scripts": "4.0.1"
   },

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -12,6 +12,7 @@ import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import useFirebaseSnapshot from '../hooks/useFirebaseSnapshot.js';
 import cleanData from '../utils/cleanData.js';
 import itemStatus from '../utils/itemStatus.js';
+import FlipMove from 'react-flip-move';
 
 const ItemList = () => {
   const { docs, loading } = useFirebaseSnapshot();
@@ -114,66 +115,74 @@ const ItemList = () => {
             ></button>
           </form>
           <ul>
-            {filteredResults
-              ? filteredResults.map((item) => (
-                  <li
-                    key={item.id}
-                    aria-label={
-                      itemStatus(item) === 'inactive'
-                        ? `${item.data.name} is inactive`
-                        : `Need to buy ${item.data.name} ${itemStatus(item)}`
-                    }
-                    className={itemStatus(item).replace(/\s+/g, '')}
-                  >
-                    {' '}
-                    <input
-                      aria-label="purchase item"
-                      type="checkbox"
-                      onChange={() => handleChecked(item.id, item)}
-                      checked={within24Hours(item)}
-                      disabled={within24Hours(item)}
-                    />{' '}
-                    {item.data.name}
-                    <button
-                      type="button"
-                      aria-label={`delete ${item.data.name}`}
-                      onClick={() => handleDelete(item.id, item.data.name)}
+            <FlipMove
+              delay={100}
+              duration={500}
+              staggerDelayBy={20}
+              enterAnimation={'elevator'}
+              leaveAnimation={'elevator'}
+            >
+              {filteredResults
+                ? filteredResults.map((item) => (
+                    <li
+                      key={item.id}
+                      aria-label={
+                        itemStatus(item) === 'inactive'
+                          ? `${item.data.name} is inactive`
+                          : `Need to buy ${item.data.name} ${itemStatus(item)}`
+                      }
+                      className={itemStatus(item).replace(/\s+/g, '')}
                     >
-                      Delete
-                    </button>
-                  </li>
-                ))
-              : docs.map((item) => (
-                  <li
-                    key={item.id}
-                    aria-label={
-                      itemStatus(item) === 'inactive'
-                        ? `${item.data.name} is inactive`
-                        : `Need to buy ${item.data.name} ${itemStatus(item)}`
-                    }
-                    className={itemStatus(item).replace(/\s+/g, '')}
-                  >
-                    {' '}
-                    <input
-                      aria-label="purchase item"
-                      type="checkbox"
-                      onChange={() => handleChecked(item.id, item)}
-                      checked={within24Hours(item)}
-                      disabled={within24Hours(item)}
-                    />{' '}
-                    {item.data.name}
-                    {/* {itemStatus(item)} */}
-                    {/* {' np: ' + item.data['next purchase']}
+                      {' '}
+                      <input
+                        aria-label="purchase item"
+                        type="checkbox"
+                        onChange={() => handleChecked(item.id, item)}
+                        checked={within24Hours(item)}
+                        disabled={within24Hours(item)}
+                      />{' '}
+                      {item.data.name}
+                      <button
+                        type="button"
+                        aria-label={`delete ${item.data.name}`}
+                        onClick={() => handleDelete(item.id, item.data.name)}
+                      >
+                        Delete
+                      </button>
+                    </li>
+                  ))
+                : docs.map((item) => (
+                    <li
+                      key={item.id}
+                      aria-label={
+                        itemStatus(item) === 'inactive'
+                          ? `${item.data.name} is inactive`
+                          : `Need to buy ${item.data.name} ${itemStatus(item)}`
+                      }
+                      className={itemStatus(item).replace(/\s+/g, '')}
+                    >
+                      {' '}
+                      <input
+                        aria-label="purchase item"
+                        type="checkbox"
+                        onChange={() => handleChecked(item.id, item)}
+                        checked={within24Hours(item)}
+                        disabled={within24Hours(item)}
+                      />{' '}
+                      {item.data.name}
+                      {/* {itemStatus(item)} */}
+                      {/* {' np: ' + item.data['next purchase']}
                     {' epi: ' + item.data['estimated purchase interval']} */}
-                    <button
-                      type="button"
-                      aria-label={`delete ${item.data.name}`}
-                      onClick={() => handleDelete(item.id, item.data.name)}
-                    >
-                      Delete
-                    </button>
-                  </li>
-                ))}
+                      <button
+                        type="button"
+                        aria-label={`delete ${item.data.name}`}
+                        onClick={() => handleDelete(item.id, item.data.name)}
+                      >
+                        Delete
+                      </button>
+                    </li>
+                  ))}
+            </FlipMove>
           </ul>
         </>
       )}


### PR DESCRIPTION
## Description

In this PR, we have installed a dependency called FlipMove, which allows animating a list upon reorder. When a user purchases or deletes an item or filters the item list, the list animates, allowing the user to more easily follow what is happening. After running into difficulties with preventing the item list from re-sorting after purchase/delete, we feel that providing visual cues using this animation instead is a good compromise.

## Related Issue

closes #45 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|  ✓ | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Short video clip of feature:
![Screen_Recording_2022-02-22_at_6_25_53_PM_AdobeCreativeCloudExpress](https://user-images.githubusercontent.com/61766455/155257548-5e806ff7-ec7d-4ad9-ab7a-71951d196bbf.gif)

## Testing Steps / QA Criteria

- Pull down branch
- Run npm install to install flipmove dependency
- Run npm start to start app
- Filter the list, purchase, or delete an item to see animation

