### PR TITLE
Fix bug so UI updates when purchasing and deleting items after filter…

### DIFF
--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -57,7 +57,7 @@ const ItemList = () => {
       const name = cleanData(item.data.name);
       return name.includes(cleanData(query));
     });
-    setFilteredResults(results);
+    !query ? setFilteredResults('') : setFilteredResults(results);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR fixes a bug where the UI does not update after clearing the filter items input field with the keyboard delete button and then purchasing or deleting items.

## Related Issue

closes #48 

## Acceptance Criteria

The UI updates (checkmark is checked after purchase) (item disappears after deletion) after a user clears out the filter items input by using the delete button on keyboard.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Testing Steps / QA Criteria

- Pull down the branch and run app
- Make sure you have items in your list
- Filter list by typing something in the filter items input field
- Use the delete button on keyboard to 'clear out' field but don't click clear button
- Purchase or delete an item (UI should update appropriately)

